### PR TITLE
Fix: README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 -->
 
 This module creates EventBridge (formerly CloudWatch Events) rules for AWS Personal Health Dashboard Events and an SNS topic. EventBridge will publish messages to this SNS topic, which can be subcribed to using this module as well.
+Since AWS Personal Health Dashboard is a global service, but since the KMS key and SNS topic are regional, this module is technically regional but only needs to be deployed once per account.
 
 ---
 
@@ -136,7 +137,7 @@ module "health_events" {
 ## Examples
 
 Here is an example of using this module:
-- [`examples/complete`](https://github.com/cloudposse/terraform-aws-health-events/) - complete example of using this module
+- [`examples/complete`](https://github.com/cloudposse/terraform-aws-health-events/examples/complete) - complete example of using this module
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -58,6 +58,7 @@ references:
 # Short description of this project
 description: |-
   This module creates EventBridge (formerly CloudWatch Events) rules for AWS Personal Health Dashboard Events and an SNS topic. EventBridge will publish messages to this SNS topic, which can be subcribed to using this module as well.
+  Since AWS Personal Health Dashboard is a global service, but since the KMS key and SNS topic are regional, this module is technically regional but only needs to be deployed once per account.
 
 # Introduction to the project
 #introduction: |-
@@ -105,7 +106,7 @@ usage: |-
 # Example usage
 examples: |-
   Here is an example of using this module:
-  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-health-events/) - complete example of using this module
+  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-health-events/examples/complete) - complete example of using this module
 
 # How to get started quickly
 #quickstart: |-


### PR DESCRIPTION
## what
* Fix link to example in README
* Extend README module description to explain that this module is technically regional but only needs to be deployed once per account.

## why
* A link was broken in the README, some extra context on module usage was also required.

## references
* N/A

