### PR TITLE
Fix: versions.tf file for examples/complete

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Fix `versions.tf` file for `examples/complete`

## why
* Ensure the `version.tf` file matches root-level `versions.tf` file (and reflects actual supported Terraform version and providers used in the `examples/complete` configuration).

## references
* #2 
