### PR TITLE
modify aws_cloudwatch_event_rule to allow custom event rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,18 +24,7 @@ resource "aws_cloudwatch_event_rule" "health_events" {
       "source" : [
         "aws.health"
       ],
-      "detail-type" : [
-        "AWS Health Event"
-      ]
-      "detail" : {
-        "service" : [
-          each.value.event_rule_pattern.detail.service
-        ]
-        "eventTypeCategory" : [
-          each.value.event_rule_pattern.detail.event_type_category
-        ]
-        "eventTypeCode" : each.value.event_rule_pattern.detail.event_type_codes
-      }
+
     }
   )
 }


### PR DESCRIPTION
## what

I made a simple modification since I wanted to receive ALL aws health notifications.

## why

The event_pattern attribute inside aws_cloudwatch_event_rule resource was not allowing to ignore the next definitions in the yaml file:

  event_rule_pattern:
    detail:
      service: 
      event_type_category: 
      event_type_codes: 
Those were mandatory fields in the module but aws did not recognize this pattern correctly when they are filled as 'null'. This caused the events not to be triggered.


